### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ upvote 和 downvote 机制
 
 ---
 
-####安装方法:
+#### 安装方法:
 
 - 对 *nix 系统，请直接执行 `source venv/bin/activate` 以获得对应的 Python 环境
 - 执行以下命令来安装依赖(适用于 Ubuntu 14.04 LTS)：


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
